### PR TITLE
[Feature for #3] Added Activity choice through command-line

### DIFF
--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -69,7 +69,14 @@ cd www
 rm -rf *
 cd ..
 
-echo --- Copying content
+echo --- Reading arguments
+
+minsize=false
+full=false
+release=false
+sign=false
+os=false
+
 for i in $*; do 
   if [ ${i%%=*} = "exclude-activities" ]
   then 
@@ -118,16 +125,32 @@ for i in $*; do
     done
     echo -e "]" >> ../sugarizer/activities.json
     sed -i "$(( $( wc -l < ../sugarizer/activities.json) -1 ))s/,$//" ../sugarizer/activities.json
+  elif [ $i = "minsize" ]
+  then
+    minsize=true
+  elif [ $i = "full" ]
+  then
+    full=true
+  elif [ $i = "release" ]
+  then
+    release=true
+  elif [ $i = "sign" ]
+  then
+    sign=true
+  elif [ $i = "os" ]
+  then
+    os=true
   fi
 done
 
+echo --- Copying content
 rsync -av --exclude-from='exclude.android' ../sugarizer/* www
 
 rm ../sugarizer/activities.json
 mv ../sugarizer/activities.bak.json ../sugarizer/activities.json
 
 cp etoys_remote.index.html www/activities/Etoys.activity/index.html
-if [ "$1" == "minsize" -o "$2" == "minsize" -o "$3" == "minsize" -o "$4" == "minsize" ]; then
+if [ $minsize == true ]; then
 	rm -rf www/activities/Abecedarium.activity/audio/en/*
 	rm -rf www/activities/Abecedarium.activity/audio/fr/*
 	rm -rf www/activities/Abecedarium.activity/audio/es/*
@@ -135,7 +158,7 @@ if [ "$1" == "minsize" -o "$2" == "minsize" -o "$3" == "minsize" -o "$4" == "min
 	rm -rf www/activities/Scratch.activity/static/internal-assets/*
 	sed -i -e 's/class="offlinemode"//' www/activities/Scratch.activity/index.html
 fi
-if [ "$1" != "full" -a "$2" != "full" -a "$3" != "full" -a "$4" != "full" ]; then
+if [ $full == true ]; then
 	echo --- Minimize Javascript files
 	cd ../sugarizer
 	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-contrib-uglify
@@ -181,7 +204,7 @@ cp ../sugarizer/res/splash/android/drawable-port-xxhdpi.png ../sugarizer-cordova
 cp ../sugarizer/res/splash/android/drawable-port-xxxhdpi.png ../sugarizer-cordova/platforms/android/res/drawable-port-xxxhdpi/screen.png
 
 rm -f platforms/android/build/outputs/apk/*.apk
-if [ "$1" == "release" -o "$2" == "release" -o "$3" == "release" -o "$4" == "release" -o "$1" == "sign" -o "$2" == "sign" -o "$3" == "sign" -o "$4" == "sign" ]; then
+if [ $release == true -o $sign == true ]; then
 	echo --- Build Cordova release version
 	FILENAME=android-release-unsigned.apk
 	cordova build android --release
@@ -193,7 +216,7 @@ fi
 
 
 echo --- Sign release version
-if [ "$1" == "sign" -o "$2" == "sign" -o "$3" == "sign" -o "$4" == "sign" ]; then
+if [ $sign == true ]; then
 	cd platforms/android/build/outputs/apk
 	jarsigner -storepass ${SUGARIZER_STOREPASS} -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore /output/${SUGARIZER_KEYSTOREFILE} android-release-unsigned.apk ${SUGARIZER_STOREALIAS}
 	jarsigner -verify -verbose -certs android-release-unsigned.apk
@@ -203,7 +226,7 @@ if [ "$1" == "sign" -o "$2" == "sign" -o "$3" == "sign" -o "$4" == "sign" ]; the
 fi
 
 echo --- Copy APK to output
-if [ "$1" == "os" -o "$2" == "os" -o "$3" == "os" -o "$4" == "os" ]; then
+if [ $os == true ]; then
 	cp /sugarizer-cordova/platforms/android/build/outputs/apk/$FILENAME /output/sugarizeros.apk
 else
 	cp /sugarizer-cordova/platforms/android/build/outputs/apk/$FILENAME /output/sugarizer.apk

--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -62,46 +62,46 @@ os=false
 excluded=false
 
 for i in $*; do 
-  if [ ${i%%=*} = "exclude-activities" ]
-  then 
-    activities=${i#*=}
-    lastActivity=${activities##*,}
-    remaining=true
-    excluded=true
-    cp exclude.android exclude.bak.android
-    echo -e "\n" >> exclude.android
-    cp ../sugarizer/activities.json ../sugarizer/activities.bak.json
-    while [ $remaining == true ]
-    do
-      activity=${activities%%,*}
-      activities=${activities#*,}
-      if [ ${#activity} -gt 0 ]
-      then
-        sed -i "/${activity}/d" ../sugarizer/activities.json
-        echo "activities/$activity.activity/" >> exclude.android
-      fi
-      if [ $activity = $lastActivity ]
-      then
-        remaining=false
-      fi
-    done
-    sed -i "$(( $( wc -l < ../sugarizer/activities.json) -1 ))s/,$//" ../sugarizer/activities.json
-  elif [ $i = "minsize" ]
-  then
-    minsize=true
-  elif [ $i = "full" ]
-  then
-    full=true
-  elif [ $i = "release" ]
-  then
-    release=true
-  elif [ $i = "sign" ]
-  then
-    sign=true
-  elif [ $i = "os" ]
-  then
-    os=true
-  fi
+	if [ ${i%%=*} = "exclude-activities" ]
+	then 
+		activities=${i#*=}
+		lastActivity=${activities##*,}
+		remaining=true
+		excluded=true
+		cp exclude.android exclude.bak.android
+		echo -e "\n" >> exclude.android
+		cp ../sugarizer/activities.json ../sugarizer/activities.bak.json
+		while [ $remaining == true ]
+		do
+			activity=${activities%%,*}
+			activities=${activities#*,}
+			if [ ${#activity} -gt 0 ]
+			then
+				sed -i "/${activity}/d" ../sugarizer/activities.json
+				echo "activities/$activity.activity/" >> exclude.android
+			fi
+			if [ $activity = $lastActivity ]
+			then
+				remaining=false
+			fi
+		done
+		sed -i "$(( $( wc -l < ../sugarizer/activities.json) -1 ))s/,$//" ../sugarizer/activities.json
+	elif [ $i = "minsize" ]
+	then
+		minsize=true
+	elif [ $i = "full" ]
+	then
+		full=true
+	elif [ $i = "release" ]
+	then
+		release=true
+	elif [ $i = "sign" ]
+	then
+		sign=true
+	elif [ $i = "os" ]
+	then
+		os=true
+	fi
 done
 
 echo --- Detect Sugarizeros
@@ -141,12 +141,12 @@ if [ $full == true ]; then
 	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-contrib-uglify
 	grunt -v
 	cd ../sugarizer-cordova
-  rsync -av --exclude-from='exclude.android' ../sugarizer/build/* www
+	rsync -av --exclude-from='exclude.android' ../sugarizer/build/* www
 fi
 if [ $excluded == true ]
 then
-  rm exclude.android
-  mv exclude.bak.android exclude.android
+	rm exclude.android
+	mv exclude.bak.android exclude.android
 fi
 
 mkdir -p ../sugarizer-cordova/platforms/android/res/mipmap-xxhdpi

--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -59,6 +59,7 @@ full=false
 release=false
 sign=false
 os=false
+excluded=false
 
 for i in $*; do 
   if [ ${i%%=*} = "exclude-activities" ]
@@ -66,6 +67,8 @@ for i in $*; do
     activities=${i#*=}
     lastActivity=${activities##*,}
     remaining=true
+    excluded=true
+    cp exclude.android exclude.bak.android
     echo -e "\n" >> exclude.android
     cp ../sugarizer/activities.json ../sugarizer/activities.bak.json
     while [ $remaining == true ]
@@ -82,31 +85,6 @@ for i in $*; do
         remaining=false
       fi
     done
-    sed -i "$(( $( wc -l < ../sugarizer/activities.json) ))s/,$//" ../sugarizer/activities.json
-  elif [ ${i%%=*} = "include-activities" ]
-  then
-    touch include.android
-    activities=${i#*=}
-    lastActivity=${activities##*,}
-    remaining=true
-    mv ../sugarizer/activities.json ../sugarizer/activities.bak.json
-    touch ../sugarizer/activities.json
-    echo -e "[" >> ../sugarizer/activities.json
-    while [ $remaining == true ]
-    do
-      activity=${activities%%,*}
-      activities=${activities#*,}
-      if [ ${#activity} -gt 0 ]
-      then
-        grep ${activity} ../sugarizer/activities.bak.json >> ../sugarizer/activities.json
-        echo "activities/$activity.activity/" >> include.android
-      fi
-      if [ $activity = $lastActivity ]
-      then
-        remaining=false
-      fi
-    done
-    echo -e "]" >> ../sugarizer/activities.json
     sed -i "$(( $( wc -l < ../sugarizer/activities.json) -1 ))s/,$//" ../sugarizer/activities.json
   elif [ $i = "minsize" ]
   then
@@ -163,9 +141,14 @@ if [ $full == true ]; then
 	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-contrib-uglify
 	grunt -v
 	cd ../sugarizer-cordova
-  rsync -rav --exclude-from='exclude.android' ../sugarizer/build/* www/
-	# cp -r ../sugarizer/build/* www/
+  rsync -av --exclude-from='exclude.android' ../sugarizer/build/* www
 fi
+if [ $excluded == true ]
+then
+  rm exclude.android
+  mv exclude.bak.android exclude.android
+fi
+
 mkdir -p ../sugarizer-cordova/platforms/android/res/mipmap-xxhdpi
 mkdir -p ../sugarizer-cordova/platforms/android/res/mipmap-xxxhdpi
 mkdir -p ../sugarizer-cordova/platforms/android/res/mipmap-ldpi

--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -135,7 +135,7 @@ if [ $minsize == true ]; then
 	rm -rf www/activities/Scratch.activity/static/internal-assets/*
 	sed -i -e 's/class="offlinemode"//' www/activities/Scratch.activity/index.html
 fi
-if [ $full == true ]; then
+if [ $full != true ]; then
 	echo --- Minimize Javascript files
 	cd ../sugarizer
 	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-contrib-uglify

--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -53,24 +53,7 @@ cordova plugin add cordova-plugin-whitelist@1.3.1
 cordova plugin add cordova-plugin-ionic-keyboard@2.2.0
 cordova plugin add https://github.com/manusimpson/Phonegap-Android-VolumeControl.git
 
-echo --- Detect Sugarizeros
-if [ "$1" == "os" -o "$2" == "os" -o "$3" == "os" ]; then
-	sed -i -e "s/&SugarizerOS/ -->/" config.xml
-	sed -i -e "s/SugarizerOS&/<!-- /" config.xml
-	sed -i -e "s/org.olpc_france.sugarizer/org.olpc_france.sugarizeros/" config.xml
-	sed -i -e "s/<name>Sugarizer/<name>Sugarizer OS/" config.xml
-	cordova plugin add ../cordova-plugin-sugarizeros
-else
-	cordova plugin remove cordova-plugin-sugarizeros
-fi
-
-echo --- Deleting previous content...
-cd www
-rm -rf *
-cd ..
-
 echo --- Reading arguments
-
 minsize=false
 full=false
 release=false
@@ -143,6 +126,22 @@ for i in $*; do
   fi
 done
 
+echo --- Detect Sugarizeros
+if [ $os == true ]; then
+	sed -i -e "s/&SugarizerOS/ -->/" config.xml
+	sed -i -e "s/SugarizerOS&/<!-- /" config.xml
+	sed -i -e "s/org.olpc_france.sugarizer/org.olpc_france.sugarizeros/" config.xml
+	sed -i -e "s/<name>Sugarizer/<name>Sugarizer OS/" config.xml
+	cordova plugin add ../cordova-plugin-sugarizeros
+else
+	cordova plugin remove cordova-plugin-sugarizeros
+fi
+
+echo --- Deleting previous content...
+cd www
+rm -rf *
+cd ..
+
 echo --- Copying content
 rsync -av --exclude-from='exclude.android' ../sugarizer/* www
 
@@ -164,7 +163,8 @@ if [ $full == true ]; then
 	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-contrib-uglify
 	grunt -v
 	cd ../sugarizer-cordova
-	cp -r ../sugarizer/build/* www/
+  rsync -rav --exclude-from='exclude.android' ../sugarizer/build/* www/
+	# cp -r ../sugarizer/build/* www/
 fi
 mkdir -p ../sugarizer-cordova/platforms/android/res/mipmap-xxhdpi
 mkdir -p ../sugarizer-cordova/platforms/android/res/mipmap-xxxhdpi


### PR DESCRIPTION
Implemented and tested my solution as discussed in #3.

***Testing***
To test the changes, edit the `make_android.sh` as per this PR by changing the --entrypoint for docker. Then execute the following command:
```shell
bash make_android.sh exclude-activities=TurtleBlocksJS,Abecedarium,Scratch
```
Note: Specify the activity name as the string before `.activity` for its directory in `/activities` separated by commas without spaces. Eg: "EbookReader" for EbookReader.activity

Yet to implement:
- [ ] Possibly specifying the choices through environment variables