### PR TITLE
Replaced Uglify-js by Terser for ES6+ minification

### DIFF
--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -137,11 +137,11 @@ if [ $minsize == true ]; then
 fi
 if [ $full != true ]; then
 	echo --- Minimize Javascript files
-	cd ../sugarizer
+	cd www
 	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-terser
 	grunt -v
-	cd ../sugarizer-cordova
-	rsync -av --exclude-from='exclude.android' ../sugarizer/build/* www
+	rm -rf node_modules
+	cd ..
 fi
 if [ $excluded == true ]
 then

--- a/src/make_android.sh
+++ b/src/make_android.sh
@@ -138,7 +138,7 @@ fi
 if [ $full != true ]; then
 	echo --- Minimize Javascript files
 	cd ../sugarizer
-	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-contrib-uglify
+	npm install grunt grunt-contrib-jshint grunt-contrib-nodeunit grunt-terser
 	grunt -v
 	cd ../sugarizer-cordova
 	rsync -av --exclude-from='exclude.android' ../sugarizer/build/* www


### PR DESCRIPTION
This PR replaces the Uglify-js dependency by new and improved Terser, which can minify ES6+ syntax as well. The modification was discussed [here](https://github.com/llaske/sugarizer-apkbuilder/issues/3#issuecomment-612850952). 

The performance benchmarks for Terser can be seen [here](https://github.com/babel/minify#benchmarks).

Please check llaske/sugarizer#783 for configuration details.